### PR TITLE
Implement TidePredictionPair finding algorithm and Display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "env_logger"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +100,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -373,6 +386,7 @@ version = "0.1.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -386,12 +400,14 @@ dependencies = [
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
+"checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
+"checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)" = "c6785aa7dd976f5fbf3b71cfd9cd49d7f783c1ff565a858d71031c6c313aa5c6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ env_logger = "0.6.1"
 chrono = { version = "0.4", features=["serde"]}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+itertools = "0.8.0"

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -1,0 +1,125 @@
+use chrono::prelude::*;
+use crate::model::{TidePrediction, TidePredictionPair};
+
+pub fn find_nearest_prediction(
+    tides: &[TidePrediction],
+    time: DateTime<FixedOffset>,
+) -> Option<TidePrediction> {
+    let mut deltas: Vec<_> = tides.into();
+    deltas.sort_by_key(|x| (x.time.timestamp() - time.timestamp()).abs());
+    deltas.first().cloned()
+}
+
+pub fn find_nearest_pair(
+    tides: &[TidePrediction],
+    time: DateTime<FixedOffset>,
+) -> TidePredictionPair {
+    let mut deltas: Vec<_> = tides.into();
+    deltas.sort_by_key(|x| x.time.timestamp() - time.timestamp());
+    let (after, before): (Vec<_>, Vec<_>) = deltas
+        .into_iter()
+        .partition(|x| x.time.timestamp() - time.timestamp() >= 0);
+
+    TidePredictionPair {
+        next: after.first().cloned(),
+        prev: before.last().cloned(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn it_returns_a_matching_prediction() {
+        let time = FixedOffset::west(8 * 3600)
+            .ymd(2019, 05, 14)
+            .and_hms(0, 0, 0);
+
+        let tide = TidePrediction { tide: 0.5, time };
+
+        let tides = vec![tide];
+
+        let found = find_nearest_prediction(&tides, time);
+        assert_eq!(found, Some(tide));
+    }
+
+    #[test]
+    fn it_returns_the_nearest_prediction() {
+        let time1 = FixedOffset::west(8 * 3600)
+            .ymd(2019, 05, 14)
+            .and_hms(0, 0, 0);
+
+        let time2 = FixedOffset::west(8 * 3600)
+            .ymd(2019, 05, 14)
+            .and_hms(1, 0, 0);
+
+        let time3 = FixedOffset::west(8 * 3600)
+            .ymd(2019, 05, 18)
+            .and_hms(0, 0, 0);
+
+        let tide1 = TidePrediction {
+            tide: 1.0,
+            time: time1,
+        };
+        let tide2 = TidePrediction {
+            tide: 2.0,
+            time: time2,
+        };
+        let tide3 = TidePrediction {
+            tide: 3.0,
+            time: time3,
+        };
+
+        let tides = vec![tide1, tide2, tide3];
+
+        let test_time = FixedOffset::west(8 * 3600)
+            .ymd(2019, 05, 14)
+            .and_hms(0, 59, 0);
+
+        let found = find_nearest_prediction(&tides, test_time);
+        assert_eq!(found, Some(tide2));
+    }
+
+    #[test]
+    fn it_finds_the_nearest_pair() {
+        let pst = FixedOffset::west(8 * 3600);
+        let time1 = pst.ymd(2019, 05, 14).and_hms(0, 0, 0);
+
+        let time2 = pst.ymd(2019, 05, 14).and_hms(1, 0, 0);
+
+        let time3 = pst.ymd(2019, 05, 18).and_hms(0, 0, 0);
+
+        let time4 = pst.ymd(2019, 05, 18).and_hms(1, 0, 0);
+
+        let tide1 = TidePrediction {
+            tide: 1.0,
+            time: time1,
+        };
+        let tide2 = TidePrediction {
+            tide: 2.0,
+            time: time2,
+        };
+        let tide3 = TidePrediction {
+            tide: 3.0,
+            time: time3,
+        };
+        let tide4 = TidePrediction {
+            tide: 4.0,
+            time: time4,
+        };
+
+        let tides = vec![tide1, tide2, tide3, tide4];
+
+        let test_time = pst.ymd(2019, 05, 15).and_hms(0, 59, 0);
+
+        let found = find_nearest_pair(&tides, test_time);
+        assert_eq!(
+            found,
+            TidePredictionPair {
+                next: Some(tide3),
+                prev: Some(tide2)
+            }
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use chrono::prelude::*;
 use simple_server::{Method, Server, StatusCode};
 
-mod model;
 mod compute;
+mod model;
 
 static PREDICTIONS_SRC: &'static str = include_str!("predictions.json");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use chrono::prelude::*;
 use simple_server::{Method, Server, StatusCode};
 
 mod model;
+mod compute;
 
 static PREDICTIONS_SRC: &'static str = include_str!("predictions.json");
 
@@ -30,14 +31,18 @@ fn main() {
 
 fn home_page(predictions: &[model::TidePrediction]) -> String {
     let time = now_in_pst();
-    let tide = model::find_nearest_prediction(&predictions, time);
+    let tide = compute::find_nearest_prediction(&predictions, time);
+    let pair = compute::find_nearest_pair(&predictions, time);
     format!(
         "<html><h1>What Tide Is It Right Now?!</h1>
         <p>It is currently {}</p>
         <p>The nearest available tide prediction from Point Atkinson is:</p>
-        <p>{:?}!</p></html>",
-        time.to_rfc2822(),
-        tide
+        <p>{:?}!</p>
+        <p>{}</p>
+        </html>",
+        time.format(model::TIME_FORMAT),
+        tide,
+        pair
     )
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -10,6 +10,16 @@ pub struct TidePrediction {
     pub time: DateTime<FixedOffset>,
 }
 
+impl TidePrediction {
+    pub fn delta_from(&self, time: DateTime<FixedOffset>) -> i64 {
+        self.time.timestamp() - time.timestamp()
+    }
+
+    pub fn is_before(&self, time: DateTime<FixedOffset>) -> bool {
+        self.time < time
+    }
+}
+
 impl fmt::Display for TidePrediction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
@@ -51,4 +61,3 @@ fn print_pair(f: &mut fmt::Formatter, n: TidePrediction, p: TidePrediction) -> f
         )
     }
 }
-


### PR DESCRIPTION
This commit introduces major new functionality for WTIIRN: the ability
to know WHICH WAY THE TIDE IS GOING!

This major feature improvement is implemented by introducing a new
struct, the `TidePredictionPair`, along with the algorithm to generate
it from a list of tides and a time.

By determining the most recent and next tide predictions, we can
determine the directionality of the tide, and display it to the user. By
implementing the `fmt::Display` trait for both `TidePrediction`s and
`TidePredictionPair`s, we can now render these stucts much more nicely.

Along the way, I also decided to seperate out the algorithms into their
own module, `compute`.