### PR TITLE
Configure host and port at run time

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,6 +5,8 @@
   "success_url": "/",
   "keywords": ["rust"],
   "env": {
-    "BUILDPACK_URL": "https://github.com/emk/heroku-buildpack-rust.git"
+    "BUILDPACK_URL": "https://github.com/emk/heroku-buildpack-rust.git",
+    "WTIIRN_HOST": "",
+    "WTIIRN_PORT": 80
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use chrono::prelude::*;
 use simple_server::{Method, Server, StatusCode};
 
@@ -6,8 +8,8 @@ mod model;
 static PREDICTIONS_SRC: &'static str = include_str!("predictions.json");
 
 fn main() {
-    let host = "127.0.0.1";
-    let port = "7878";
+    let host = env::var("WTIIRN_HOST").unwrap_or("127.0.0.1".to_string());
+    let port = env::var("WTIIRN_PORT").unwrap_or("7878".to_string());
 
     let predictions = parse_predictions(PREDICTIONS_SRC);
 
@@ -25,7 +27,7 @@ fn main() {
     });
 
     println!("Server listening on port: {}", port);
-    server.listen(host, port);
+    server.listen(&host, &port);
 }
 
 fn home_page(predictions: &[model::TidePrediction]) -> String {


### PR DESCRIPTION
This commit adds configuration options for the Hostname and Port
that WTiiRN will listen on when it boots. The defaults are the
same as before, but they can be configured with the environment
variables WTIIRN_HOST and WTIIRN_PORT