### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: rust
+rust:
+  - stable
+  - beta
+cache: cargo


### PR DESCRIPTION
This commit adds a .travis.yml file that builds and tests
WTiirN's rust code on stable and beta Rust.

The configuration was based on Travis's documentation here:

https://docs.travis-ci.com/user/languages/rust/

Travis CI was chosen as it appears to have decent Rust support.