### PR TITLE
Add location information request

### DIFF
--- a/public/getlocation.js
+++ b/public/getlocation.js
@@ -1,0 +1,20 @@
+function reloadWithLocation(pos) {
+  let coords = pos.coords;
+  let latlon =
+    "lat=" + coords.latitude.toString() + "&lon=" + coords.longitude.toString();
+  let newUrl = "/?" + latlon;
+  window.location.replace(newUrl);
+}
+
+function getLocationAndReload() {
+  if ("geolocation" in navigator) {
+    let geo = navigator.geolocation;
+    geo.getCurrentPosition(reloadWithLocation, console.error);
+  }
+}
+
+window.onload = function() {
+  if (!window.location.search) {
+    getLocationAndReload();
+  }
+};

--- a/src/pages.rs
+++ b/src/pages.rs
@@ -26,6 +26,7 @@ pub fn home_page(predictions: &[model::TidePrediction]) -> String {
                         </div>
                     </div>
                 </div>
+                <script src='getlocation.js'></script>
             </body>
         </html>",
         pair.headline(),


### PR DESCRIPTION
This commit adds a script which requests the client's location and
reloads the page with that information in the query string. This
behavior is suppressed if there is already a query string present.