### PR TITLE
Add great circle distance calculation

### DIFF
--- a/src/compute.rs
+++ b/src/compute.rs
@@ -1,17 +1,6 @@
-use crate::model::{TidePrediction, TidePredictionPair};
 use chrono::prelude::*;
+use crate::model::{TidePrediction, TidePredictionPair};
 use itertools::Itertools;
-
-pub fn find_nearest_prediction(
-    tides: &[TidePrediction],
-    time: DateTime<FixedOffset>,
-) -> Option<TidePrediction> {
-    tides
-        .iter()
-        .sorted_by_key(|x| x.delta_from(time).abs())
-        .next()
-        .cloned()
-}
 
 pub fn find_nearest_pair(
     tides: &[TidePrediction],
@@ -31,57 +20,6 @@ pub fn find_nearest_pair(
 #[cfg(test)]
 mod test {
     use super::*;
-
-    #[test]
-    fn it_returns_a_matching_prediction() {
-        let time = FixedOffset::west(8 * 3600)
-            .ymd(2019, 05, 14)
-            .and_hms(0, 0, 0);
-
-        let tide = TidePrediction { tide: 0.5, time };
-
-        let tides = vec![tide];
-
-        let found = find_nearest_prediction(&tides, time);
-        assert_eq!(found, Some(tide));
-    }
-
-    #[test]
-    fn it_returns_the_nearest_prediction() {
-        let time1 = FixedOffset::west(8 * 3600)
-            .ymd(2019, 05, 14)
-            .and_hms(0, 0, 0);
-
-        let time2 = FixedOffset::west(8 * 3600)
-            .ymd(2019, 05, 14)
-            .and_hms(1, 0, 0);
-
-        let time3 = FixedOffset::west(8 * 3600)
-            .ymd(2019, 05, 18)
-            .and_hms(0, 0, 0);
-
-        let tide1 = TidePrediction {
-            tide: 1.0,
-            time: time1,
-        };
-        let tide2 = TidePrediction {
-            tide: 2.0,
-            time: time2,
-        };
-        let tide3 = TidePrediction {
-            tide: 3.0,
-            time: time3,
-        };
-
-        let tides = vec![tide1, tide2, tide3];
-
-        let test_time = FixedOffset::west(8 * 3600)
-            .ymd(2019, 05, 14)
-            .and_hms(0, 59, 0);
-
-        let found = find_nearest_prediction(&tides, test_time);
-        assert_eq!(found, Some(tide2));
-    }
 
     #[test]
     fn it_finds_the_nearest_pair() {

--- a/src/model.rs
+++ b/src/model.rs
@@ -77,3 +77,122 @@ fn detail(n: TidePrediction, p: TidePrediction) -> String {
         format!("High tide was {}, Low tide will be {}", p, n)
     }
 }
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub struct Coordinates {
+    pub lat: f64,
+    pub lon: f64,
+}
+
+impl Coordinates {
+    /// Lat and Lon in radians.
+    fn to_radians(&self) -> (f64, f64) {
+        (
+            self.lat * std::f64::consts::PI / 180.0,
+            self.lon * std::f64::consts::PI / 180.0,
+        )
+    }
+}
+
+pub type Meters = f64;
+
+const EARTH_RADIUS: Meters = 6_371_000.0;
+
+/// Verify that a number is in [-1, 1], making a small allowance for floating
+/// point errors.
+fn check_acos_domain(x: f64) -> f64 {
+    const ACCEPTABLE_DELTA: f64 = 1e-11;
+    if -1.0 <= x && x <= 1.0 {
+        return x
+    }
+    if x < -1.0 && (-1.0 - ACCEPTABLE_DELTA) < x {
+        return -1.0 + std::f64::EPSILON;
+    }
+    if x > 1.0 && (1.0 + ACCEPTABLE_DELTA) > x {
+        return 1.0 - std::f64::EPSILON;
+    }
+    panic!("f64 outside of arcos range ({})", x);
+}
+
+pub fn great_circle_distance(p1: &Coordinates, p2: &Coordinates) -> Meters {
+    // https://en.wikipedia.org/wiki/Great-circle_distance
+    let (lat1, lon1) = p1.to_radians();
+    let (lat2, lon2) = p2.to_radians();
+    let delta_lon = (lon1 - lon2).abs();
+    let cos_central = lat1.sin() * lat2.sin() + lat1.cos() * lat2.cos() * delta_lon.cos();
+    println!("cos_central = {}", cos_central);
+    let central = check_acos_domain(cos_central).acos();
+    println!("central = {}", central);
+    central * EARTH_RADIUS
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const ACCEPTABLE_ERR: Meters = 0.33;
+    const EARTH_CIRC: Meters = 2.0 * std::f64::consts::PI * EARTH_RADIUS;
+
+    #[test]
+    fn distance_to_self_is_zero() {
+        let p1 = Coordinates {
+            lat: 100.0,
+            lon: 45.0,
+        };
+        assert!(great_circle_distance(&p1, &p1) < ACCEPTABLE_ERR);
+    }
+
+    #[test]
+    fn distance_from_equator_to_pole_is_one_quarter_circumference() {
+        let p1 = Coordinates { lat: 0.0, lon: 0.0 };
+        let p2 = Coordinates {
+            lat: 90.0,
+            lon: 0.0,
+        };
+        let dist = great_circle_distance(&p1, &p2);
+        assert!((dist - EARTH_CIRC / 4.0).abs() < ACCEPTABLE_ERR);
+    }
+    #[test]
+    fn distance_from_pole_to_pole_is_one_half_circumference() {
+        let p1 = Coordinates {
+            lat: -90.0,
+            lon: 0.0,
+        };
+        let p2 = Coordinates {
+            lat: 90.0,
+            lon: 0.0,
+        };
+        let dist = great_circle_distance(&p1, &p2);
+        assert!((dist - EARTH_CIRC / 2.0).abs() < ACCEPTABLE_ERR);
+    }
+
+    #[test]
+    fn quarter_circumference_centered_on_equator() {
+        // Check that the distance form 45 N to 45 S is a quarter circumference.
+        let p1 = Coordinates {
+            lat: 45.0,
+            lon: 0.0,
+        };
+        let p2 = Coordinates {
+            lat: -45.0,
+            lon: 0.0,
+        };
+        let dist = great_circle_distance(&p1, &p2);
+        assert!((dist - EARTH_CIRC / 4.0).abs() < ACCEPTABLE_ERR);
+    }
+    #[test]
+    fn two_half_turns() {
+        //Check a point halfway around the world
+        let p1 = Coordinates {
+            lat: 45.0,
+            lon: 0.0,
+        };
+        let p2 = Coordinates {
+            lat: -45.0,
+            lon: 180.0,
+        };
+        let dist = great_circle_distance(&p1, &p2);
+        println!("{} {}", dist, EARTH_CIRC / 2.0);
+        assert!((dist - EARTH_CIRC / 2.0).abs() < ACCEPTABLE_ERR);
+    }
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -11,10 +11,6 @@ pub struct TidePrediction {
 }
 
 impl TidePrediction {
-    pub fn delta_from(&self, time: DateTime<FixedOffset>) -> i64 {
-        self.time.timestamp() - time.timestamp()
-    }
-
     pub fn is_before(&self, time: DateTime<FixedOffset>) -> bool {
         self.time < time
     }


### PR DESCRIPTION
This commit adds a model for representing points on the surface of the
Earth using a simplified spherical model (not the more accurate but
trickier oblate spheroid).

Since we're on a modern 64 bit system, we can use the simpler formulas
offered here:

https://en.wikipedia.org/wiki/Great-circle_distance

Additionally, the model for representing points can transform its
lattitude and longitude data from degrees to radians (which is
necessary because Rust's stdlib trigonometric operations operate on
radians, but latitude and longitude are most commonly expressed in
degrees).
