### PR TITLE
Adopt uom crate for Measurements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ucd-util"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +338,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "uom"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "utf8-ranges"
@@ -391,6 +405,7 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple-server 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uom 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
@@ -436,8 +451,10 @@ dependencies = [
 "checksum termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum uom 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ef5bbe8385736e498dbb0033361f764ab43a435192513861447b9f7714b3fec"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ chrono = { version = "0.4", features=["serde"]}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 itertools = "0.8.0"
-uom = "0.23.1"
+uom = { version = "0.23.1", features = ["use_serde"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ chrono = { version = "0.4", features=["serde"]}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 itertools = "0.8.0"
+uom = "0.23.1"
+

--- a/src/compute/find.rs
+++ b/src/compute/find.rs
@@ -1,6 +1,8 @@
 use crate::model::{TidePrediction, TidePredictionPair};
 use chrono::prelude::*;
 use itertools::Itertools;
+use uom::si::f64::*;
+use uom::si::length::meter;
 
 pub fn nearest_pair(
     tides: &[TidePrediction],
@@ -29,19 +31,19 @@ mod test {
         let time3 = pst.ymd(2019, 05, 18).and_hms(0, 0, 0);
         let time4 = pst.ymd(2019, 05, 18).and_hms(1, 0, 0);
         let tide1 = TidePrediction {
-            tide: 1.0,
+            tide: Length::new::<meter>(1.0),
             time: time1,
         };
         let tide2 = TidePrediction {
-            tide: 2.0,
+            tide: Length::new::<meter>(2.0),
             time: time2,
         };
         let tide3 = TidePrediction {
-            tide: 3.0,
+            tide: Length::new::<meter>(3.0),
             time: time3,
         };
         let tide4 = TidePrediction {
-            tide: 4.0,
+            tide: Length::new::<meter>(4.0),
             time: time4,
         };
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -2,12 +2,14 @@ use chrono::prelude::*;
 use serde::Deserialize;
 use std::convert::TryFrom;
 use std::fmt;
+use uom::si::f64::*;
+use uom::si::length::meter;
 
 pub static TIME_FORMAT: &str = "%I:%M%P on %a %b %e, %Y";
 
 #[derive(Debug, PartialEq, Clone, Copy, Deserialize)]
 pub struct TidePrediction {
-    pub tide: f32,
+    pub tide: Length,
     pub time: DateTime<FixedOffset>,
 }
 
@@ -22,7 +24,7 @@ impl fmt::Display for TidePrediction {
         write!(
             f,
             "{} meters above the datum at {}",
-            self.tide,
+            self.tide.get::<meter>(),
             self.time.format(TIME_FORMAT)
         )
     }

--- a/src/pages.rs
+++ b/src/pages.rs
@@ -1,4 +1,6 @@
 use chrono::prelude::*;
+use uom::si::f64::*;
+use uom::si::length::{kilometer, meter};
 
 use crate::compute;
 use crate::model::{Coordinates, TidePrediction};
@@ -18,7 +20,7 @@ pub fn home_page(predictions: &[TidePrediction], current_location: &Option<Coord
     };
 
     let distance = match current_location {
-        None => 0.0,
+        None => Length::new::<meter>(0.0),
         Some(c) => compute::gcd::great_circle_distance(c, &POINT_ATKINSON),
     };
 
@@ -40,14 +42,17 @@ pub fn home_page(predictions: &[TidePrediction], current_location: &Option<Coord
                         <div class='detail'>
                             <p>{}</p>
                             <p>{:?}</p>
-                            <p>{:?}</p>
+                            <p>{}</p>
                         </div>
                     </div>
                 </div>
                 <script src='getlocation.js'></script>
             </body>
         </html>",
-        headline, detail, current_location, distance
+        headline,
+        detail,
+        current_location,
+        distance.get::<kilometer>()
     )
 }
 


### PR DESCRIPTION
This commit adds the uom crate, and uses it to replace our custom type
alias for `Meters`. This allows us to easily display the distance from
point atkinson in Kilometers rather than meters, and in the future will
allow us to work with NOAA data (in Feet) alongside our canadian data in
Meters.