### PR TITLE
Add stub API for stations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,9 @@ use simple_server::{Method, Server, StatusCode};
 
 mod compute;
 mod model;
-mod pages;
 
+mod pages;
+mod stations;
 static PREDICTIONS_SRC: &'static str = include_str!("predictions.json");
 
 fn main() {

--- a/src/stations.rs
+++ b/src/stations.rs
@@ -1,0 +1,36 @@
+use crate::model;
+
+/// The generic information about a tide station, divorced
+/// from meta-data like "how are the tides predicted" and
+/// "who's responsible for this station".
+#[derive(Debug, PartialEq)]
+pub struct Station {
+    pub name: String,
+    pub coords: model::Coordinates,
+    id: u64,
+}
+
+/// Queryable repository of stations.
+pub struct StationCatalogue {
+    stations: Vec<Station>,
+}
+
+impl StationCatalogue {
+    /// Initialize a catalogue from a suitable data source.
+    /// Panics if there isn't at least one tide station in
+    /// the initialized catalogue.
+    pub fn load() -> Self {
+        // Ensures that there's at least one tide station.
+        unimplemented!()
+    }
+
+    /// Find the station nearest to the given coordinates.
+    pub fn find_near(&self, location: &model::Coordinates) -> &Station {
+        unimplemented!()
+    }
+
+    /// Add a station's data to this catalogue, assigning it an appropriate unique id.
+    fn add(&mut self, name: &str, coords: &model::Coordinates) {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
This commit adds a stub API for stations.

This API is based on the common features of the tide prediction
infrastructure of tides.gc.ca and NOOA's [CO-OPS data service][coops].

[coops]: https://opendap.co-ops.nos.noaa.gov/axis/