### PR TITLE
Fix issues caught by Clippy

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,8 @@ mod stations;
 static PREDICTIONS_SRC: &'static str = include_str!("predictions.json");
 
 fn main() {
-    let host = env::var("WTIIRN_HOST").unwrap_or("127.0.0.1".to_string());
-    let port = env::var("PORT").unwrap_or("7878".to_string());
+    let host = env::var("WTIIRN_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+    let port = env::var("PORT").unwrap_or_else(|_| "7878".to_string());
 
     let predictions = parse_predictions(PREDICTIONS_SRC);
 
@@ -37,7 +37,6 @@ fn main() {
 }
 
 fn parse_predictions(src: &str) -> Vec<model::TidePrediction> {
-    use serde_json;
     serde_json::from_str(src).expect("Failure to parse included predictions.json")
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -104,8 +104,8 @@ impl TryFrom<&str> for Coordinates {
         let mut maybe_lat = None;
         let mut maybe_lon = None;
         let tuples = s
-            .split("&")
-            .map(|x| (x.split("=").next(), x.split("=").last()));
+            .split('&')
+            .map(|x| (x.split('=').next(), x.split('=').last()));
 
         for (name, value) in tuples {
             match (name, value) {


### PR DESCRIPTION
The issues fixed are:

- .unwrap_or ->.unwrap_or_else, which defers evaluating the default until an error
  is encountered, which can save allocations (not relevant at our scale, but a good habit).

- Splitting strings on chars which is faster than splitting on on &strs.

- Removing unused module imports. I'm *still* not 100% clear on how module imports,
  external crates, and some other features of the module system work, but the tests
  pass with that statement removed so . . . yay? Learning?