### PR TITLE
Implement HomePageViewModel

### DIFF
--- a/src/stations.rs
+++ b/src/stations.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 pub struct Station {
     pub name: String,
     pub coordinates: Coordinates,
-    id: u64,
+    pub id: u64,
 }
 
 static ATKINSON_PREDICTIONS_SRC: &'static str = include_str!("atkinson_predictions.json");


### PR DESCRIPTION
This change pushes much of the display logic for the home page into the
`HomePageViewModel`. It also provides new functionality, naming the
station used for predictions, and using a reasonable number of decimal
places for the distance between that station and the user's current
location.