### PR TITLE
Add explanation of Chart Datum to prediction

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -23,7 +23,7 @@ impl fmt::Display for TidePrediction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{} meters above the datum at {}",
+            "{} meters above the <a href='https://en.wikipedia.org/wiki/Chart_datum'>datum</a> at {}",
             self.tide.get::<meter>(),
             self.time.format(TIME_FORMAT)
         )


### PR DESCRIPTION
This commit adds an explanation of the jargon term 'Chart Datum' to
the implementation of `fmt::Display` for `TidePrediction`. which is
eventually rendered on the home page. In the future, it may make sense
to perform this task with a templating system instead, and have the
linked explanation in the homepage template rather than associating it
with the `TidePrediction`.