### PR TITLE
Rename Binary and add logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "wtiirn"
 path = "src/lib.rs"
 
 [[bin]]
-name = "server"
+name = "wtiirn"
 path = "src/main.rs"
 
 [[bin]]

--- a/src/stations.rs
+++ b/src/stations.rs
@@ -47,10 +47,13 @@ impl StationCatalogue {
     /// Panics if there isn't at least one tide station in
     /// the initialized catalogue.
     pub fn load() -> Self {
+        println!("Initializing Station Catalogue");
         let stations =
             load_stations_from_dir(Path::new("data/stations")).expect("failed to load stations");
+        println!("Loaded {} total stations", stations.len());
         let predictions = load_predictions_from_dir(Path::new("data/predictions"))
             .expect("failed to load predcitions");
+        println!("Loaded {} prediction collections", predictions.len());
 
         StationCatalogue {
             stations,


### PR DESCRIPTION
This change renames the server binary to `wtiirn`, which matches the Procfile, and thus ensures that we actually run the code that we write in production.

It also adds a few small log lines to the catalogue initialization process, to provide a small amount of observability at boot time.