### PR TITLE
First try at http -> https redirection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "http"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -450,7 +450,7 @@ name = "simple-server"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -592,6 +592,7 @@ version = "0.1.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -625,7 +626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-"checksum http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
+"checksum http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "372bcb56f939e449117fb0869c2e8fd8753a8223d92a172c6e808cf123a5b6e4"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ serde-xml-rs = "0.3.1"
 itertools = "0.8.0"
 uom = { version = "0.23.1", features = ["use_serde"] }
 uuid = { version = "0.7.4", features = ["v4", "v5", "serde"] }
+http = "0.1.18"
 
 [lib]
 name = "wtiirn"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,8 @@ use std::convert::TryInto;
 use std::env;
 use wtiirn::{pages, stations};
 
-use simple_server::{Method, Server, StatusCode};
+use http::header::{self, HeaderName};
+use simple_server::{Handler, Method, Request, ResponseBuilder, Server, StatusCode};
 
 fn main() {
     let host = env::var("WTIIRN_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
@@ -11,23 +12,75 @@ fn main() {
     let catalogue = stations::StationCatalogue::load();
 
     println!("WTIIRN booting up!");
-    let server = Server::new(move |request, mut response| {
-        println!("Request received. {} {}", request.method(), request.uri());
-        let coords = request.uri().query().try_into().ok();
-
-        match (request.method(), request.uri().path()) {
-            (&Method::GET, "/") => Ok(response.body(
-                pages::home_page(pages::HomePageViewModel::new(&catalogue, &coords))
-                    .as_bytes()
-                    .to_vec(),
-            )?),
-            (_, _) => {
-                response.status(StatusCode::NOT_FOUND);
-                Ok(response.body(pages::not_found_page().as_bytes().to_vec())?)
-            }
-        }
-    });
+    let server = Server::new(routes(catalogue));
 
     println!("Server listening on port: {}", port);
     server.listen(&host, &port);
+}
+
+fn routes(catalogue: stations::StationCatalogue) -> Handler {
+    let forwarded_proto_header = HeaderName::from_static("x-forwarded-proto");
+
+    Box::new(
+        move |request: Request<Vec<u8>>, mut response: ResponseBuilder| {
+            println!("Request received. {} {}", request.method(), request.uri());
+            let coords = request.uri().query().try_into().ok();
+
+            match (
+                request.method(),
+                request.uri().path(),
+                request
+                    .headers()
+                    .get(&forwarded_proto_header)
+                    .map(|x| x.len()),
+            ) {
+                (_, _, Some(4)) => {
+                    response
+                        .status(StatusCode::MOVED_PERMANENTLY)
+                        .header(header::LOCATION, "https://whattideisitrightnow.com");
+                    Ok(response.body(vec![])?)
+                }
+                (&Method::GET, "/", _) => Ok(response.body(
+                    pages::home_page(pages::HomePageViewModel::new(&catalogue, &coords))
+                        .as_bytes()
+                        .to_vec(),
+                )?),
+                (_, _, _) => {
+                    response.status(StatusCode::NOT_FOUND);
+                    Ok(response.body(pages::not_found_page().as_bytes().to_vec())?)
+                }
+            }
+        },
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use simple_server::Response;
+    #[test]
+    fn it_should_redirect_in_http() {
+        let routes = routes(stations::StationCatalogue::test());
+        let request = Request::builder()
+            .header("x-forwarded-proto", "http")
+            .body(vec![])
+            .unwrap();
+
+        let response = routes(request, Response::builder()).unwrap();
+
+        assert_eq!(response.status(), StatusCode::MOVED_PERMANENTLY);
+    }
+
+    #[test]
+    fn it_should_not_redirect_in_https() {
+        let routes = routes(stations::StationCatalogue::test());
+        let request = Request::builder()
+            .header("x-forwarded-proto", "https")
+            .body(vec![])
+            .unwrap();
+
+        let response = routes(request, Response::builder()).unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
 }

--- a/src/stations.rs
+++ b/src/stations.rs
@@ -43,6 +43,17 @@ impl StationCatalogue {
         }
     }
 
+    pub fn test() -> Self {
+        StationCatalogue {
+            stations: vec![Station {
+                name: "Test Station".into(),
+                coordinates: Coordinates { lat: 0.0, lon: 0.0 },
+                id: Uuid::new_v4(),
+            }],
+            predictions: vec![],
+        }
+    }
+
     /// Initialize a catalogue from a suitable data source.
     /// Panics if there isn't at least one tide station in
     /// the initialized catalogue.


### PR DESCRIPTION
This change uses the `x-forwarded-proto` header to check if heroku has
transmited the request from http, and returns a 301 redirect to the
https url in that case.

In order to test this, I extracted the route handler to a function,
which means we can now unit test our routes very easily.

I've been able to manually test that the 301 is returned locally, but
I'm still not 100% confident this will work how we expect. Fingers
crossed!