### PR TITLE
Display current tide status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-humanize"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +666,7 @@ name = "wtiirn"
 version = "0.1.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono-humanize 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -688,6 +697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "ce400c638d48ee0e9ab75aef7997609ec57367ccfe1463f21bf53c3eca67bf46"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
+"checksum chrono-humanize 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2ff48a655fe8d2dae9a39e66af7fd8ff32a879e8c4e27422c25596a8b5e90d"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ simple-server = "0.4.0"
 log = "0.4"
 env_logger = "0.6.1"
 chrono = { version = "0.4", features=["serde"]}
+chrono-humanize = "0.0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde-xml-rs = "0.3.1"

--- a/public/style.css
+++ b/public/style.css
@@ -42,3 +42,22 @@ body {
   justify-content: flex-end;
 }
 
+table {
+  table-layout: fixed;
+  border-collapse: collapse;
+  margin: auto;
+  border: 1px solid black;
+  text-align: center;
+}
+
+table td, thead th {
+  padding: 10px;
+}
+
+table tr {
+  border-bottom: 1px solid black;
+}
+
+thead tr th {
+  border-bottom: 1px solid black;
+}

--- a/src/compute/find.rs
+++ b/src/compute/find.rs
@@ -120,7 +120,10 @@ mod test {
                 tide: Length::new::<meter>(2.0),
                 time: time2,
             };
-            let pair = TidePredictionPair {prev: tide1, next: tide2};
+            let pair = TidePredictionPair {
+                prev: tide1,
+                next: tide2,
+            };
             let cases = vec![
                 (15, 1.1464466094067262),
                 (30, 1.5),
@@ -139,7 +142,10 @@ mod test {
                 tide: Length::new::<meter>(0.0),
                 time: time2,
             };
-            let pair = TidePredictionPair {prev: tide1, next: tide2};
+            let pair = TidePredictionPair {
+                prev: tide1,
+                next: tide2,
+            };
             let cases = vec![(60, 8.5355), (120, 5.0), (180, 1.4644999999999992)];
             check_cases(&pair, &cases);
         }


### PR DESCRIPTION
This change updates the homepage to display what I'm calling the
"current status" of the tide. This is a natural language representation
of what we expect users actually want to know:

If the tide is going out, then how much more will it go down, and for
how long.

This change also updates the previous "detail" display to instead show a
table, which we believe is a more useful form for the information it
contains.